### PR TITLE
FO: Cache not correctly cleared after product add, delete and update

### DIFF
--- a/productscategory.php
+++ b/productscategory.php
@@ -218,33 +218,26 @@ class ProductsCategory extends Module
 	{
 		if (!isset($params['product']))
 			return;
-		$id_product = (int)$params['product']->id;
-		$product = $params['product'];
-
-		$cache_id = 'productscategory|'.$id_product.'|'.(isset($params['category']->id_category) ? (int)$params['category']->id_category : (int)$product->id_category_default);
-		$this->_clearCache('productscategory.tpl', $this->getCacheId($cache_id));
+		$this->_clearCache('productscategory.tpl');
 	}
 
 	public function hookUpdateProduct($params)
 	{
 		if (!isset($params['product']))
 			return;
-		$id_product = (int)$params['product']->id;
-		$product = $params['product'];
-
-		$cache_id = 'productscategory|'.$id_product.'|'.(isset($params['category']->id_category) ? (int)$params['category']->id_category : (int)$product->id_category_default);
-		$this->_clearCache('productscategory.tpl', $this->getCacheId($cache_id));
+		$this->_clearCache('productscategory.tpl');
 	}
 
 	public function hookDeleteProduct($params)
 	{
 		if (!isset($params['product']))
 			return;
-		$id_product = (int)$params['product']->id;
-		$product = $params['product'];
+		$this->_clearCache('productscategory.tpl');
+	}
 
-		$cache_id = 'productscategory|'.$id_product.'|'.(isset($params['category']->id_category) ? (int)$params['category']->id_category : (int)$product->id_category_default);
-		$this->_clearCache('productscategory.tpl', $this->getCacheId($cache_id));
+	public function _clearCache($template, $cache_id = NULL, $compile_id = NULL)
+	{
+		Tools::clearCache(Context::getContext()->smarty, $this->getTemplatePath('productscategory.tpl'));
 	}
 
 	public function renderForm()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Cache not correctly cleared after product add, delete and update, this module is displayed on FO on other product, not on the product we are modifying at the BO, so we need to remove more smarty cache
| Type?         | new feature
| Category?     | FO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | see below please


How to test
- activate this module, configure it, 
- go on FO on a product page. keep in mind one of the displayed product on the block " other product in the same category"
- modify the informations of this product ( price or title for instance)
- go again on FO on the product page, inforamtions where not cleared before this proposition
